### PR TITLE
replace heroku-cli package url

### DIFF
--- a/tasks/clone_foundation_site/task.sh
+++ b/tasks/clone_foundation_site/task.sh
@@ -48,8 +48,8 @@ if [ "$?" -eq 0 ]; then
     echo "Heroku CLI is already installed..."
 else
     echo "Downloading and extracting the standalone Heroku CLI tool..."
-    curl "https://cli-assets.heroku.com/heroku-linux-x64.tar.xz" -o "heroku-linux-x64.tar.xz"
-    tar -xf heroku-linux-x64.tar.xz
+    curl "https://cli-assets.heroku.com/heroku-linux-x64.tar.gz" -o "heroku-linux-x64.tar.gz"
+    tar -xf heroku-linux-x64.tar.gz
     alias heroku=${current_dir}/heroku/bin/heroku
 fi
 


### PR DESCRIPTION
close #4 

Couldn't find a way to install `xz-utils` so let's use a `tar-gz` instead of a `tar.xz`.