### PR TITLE
Slack pipeline bot: less messy commits's messages

### DIFF
--- a/tasks/heroku_pipelines_check/slack_webhook.py
+++ b/tasks/heroku_pipelines_check/slack_webhook.py
@@ -16,6 +16,19 @@ pipelines = {
 
 slack_webhook = os.environ["SLACK_PIPELINES_WEBHOOK"]
 
+
+# Each commit line is divided into 4 columns, separated by two double spaces. We only keep the last two,
+# which contain the commit's author and title.
+def get_commits_info(commits):
+    result = []
+    for commit in commits:
+        commit = commit.split('  ')
+        commit_info = ': '.join(commit[2:4])
+        result.append(commit_info)
+
+    return result
+
+
 # Task only run from Monday to Thursday
 if date.today().weekday() in range(0, 4):
 
@@ -45,16 +58,23 @@ if date.today().weekday() in range(0, 4):
             break
         else:
             """
-            We expect Heroku output to have this structure:
+            We expect Heroku's output to have this structure:
             - line 1 is empty,
-            - line 2 is the name of the app and how much commit will be deployed to prod,
+            - line 2 is the name of the app. It also tells us if prod is behind staging or not.
             - line 3 and 4 are column titles and table structure,
             - line 5 to the third to last are commits (date, author, etc),
             - Line second to last is the GitHub diff URL,
             - Last line is an empty line.
             """
             title = output[1].strip("=\n").lstrip()
-            body = "".join(output[4:-2])
+            commits_list = output[4:-2]
+            if commits_list:
+                if len(commits_list) >= 2:
+                    attachment_title = "Commits to deploy to production:"
+                    body = "".join("- " + e for e in get_commits_info(commits_list))
+                else:
+                    attachment_title = "Commit to deploy to production:"
+                    body = get_commits_info(commits_list)[0]
             diff_url = output[-1].rstrip()
             up_to_date_regex = "is up to date"
 
@@ -69,7 +89,7 @@ if date.today().weekday() in range(0, 4):
                             f"URL to Github diff: {diff_url}\n"
                             f"URL to pipeline: https://dashboard.heroku.com/pipelines/{app}",
                             "pretext": f"{title}",
-                            "title": f"Commit(s) to deploy to production:",
+                            "title": f"{attachment_title}",
                             "text": f"{body}",
                             "color": "#36bced",
                             "actions": [


### PR DESCRIPTION
We now only keep commits' author and title to make the message posted on Slack more readable.
before:
<img width="678" alt="screen shot 2018-11-20 at 12 17 05 pm" src="https://user-images.githubusercontent.com/481052/48770341-3f047c00-ecbe-11e8-9fbf-bef8735c162d.png">
now:
<img width="598" alt="screen shot 2018-11-20 at 12 17 43 pm" src="https://user-images.githubusercontent.com/481052/48770355-4b88d480-ecbe-11e8-9ebb-0e307201fd26.png">

ref #12 