### PR TITLE
Fix the pipeline bot messages (again)

### DIFF
--- a/tasks/heroku_pipelines_check/slack_webhook.py
+++ b/tasks/heroku_pipelines_check/slack_webhook.py
@@ -22,7 +22,7 @@ slack_webhook = os.environ["SLACK_PIPELINES_WEBHOOK"]
 def get_commits_info(commits):
     result = []
     for commit in commits:
-        commit = commit.split('  ')
+        commit = re.split(r'\s{2,}', commit)
         commit_info = ': '.join(commit[2:4])
         result.append(commit_info)
 


### PR DESCRIPTION
I tested my code with commits written by only one person and totally missed that, of course, spaces between usernames and commit title would probably vary >.<