### PR TITLE
Update wagtail site hostname during clonedb

### DIFF
--- a/tasks/clone_foundation_site/cleanup.sql
+++ b/tasks/clone_foundation_site/cleanup.sql
@@ -23,6 +23,10 @@ BEGIN
     SET domain = 'foundation.mofostaging.net'
     WHERE domain = 'foundation.mozilla.org';
 
+    UPDATE wagtailcore_site
+    SET hostname = 'foundation.mofostaging.net'
+    WHERE hostname = 'foundation.mozilla.org';
+
 --     Iterate over each non-staff user and remove any PII
     FOR user_row IN
         SELECT id


### PR DESCRIPTION
Close #17
Close mozilla/foundation.mozilla.org#2340

We also need to update `wagtailcore_site` hostname or previews won't work.