### PR TITLE
remove mozfest-app from check

### DIFF
--- a/tasks/heroku_pipelines_check/slack_webhook.py
+++ b/tasks/heroku_pipelines_check/slack_webhook.py
@@ -8,7 +8,6 @@ import os
 
 pipelines = {
     "foundation-site": "foundation-mofostaging-net",
-    "mozillafestival-org": "mozillafestival-org-staging",
     "donate-mozilla-org": "donate-mozilla-org-us-staging",
     "network-pulse": "network-pulse-staging",
     "network-pulse-api": "network-pulse-api-staging",


### PR DESCRIPTION
Since the mozfest site repo is archived, let's remove it from the check.