### PR TITLE
restore ping for donate - pipelines bot

### DIFF
--- a/tasks/heroku_pipelines_check/slack_webhook.py
+++ b/tasks/heroku_pipelines_check/slack_webhook.py
@@ -67,8 +67,8 @@ if date.today().weekday() in range(0, 4):
             - Last line is an empty line.
             """
             title = output[1].strip("=\n").lstrip()
-#             if re.search("donate", title):
-#                 title = "<@tchevalier>: " + title
+            if re.search("donate", title):
+                title = "<@tchevalier>: " + title
             commits_list = output[4:-2]
             if commits_list:
                 if len(commits_list) >= 2:


### PR DESCRIPTION
The donate staging app was behind the prod app, creating a bug in `heroku:pipelines diff`. We can now restore the slack ping.