### PR TITLE
Adding donate-wagtail to heroku pipelines bot

### DIFF
--- a/tasks/heroku_pipelines_check/slack_webhook.py
+++ b/tasks/heroku_pipelines_check/slack_webhook.py
@@ -11,6 +11,7 @@ pipelines = {
     "donate-mozilla-org": "donate-mozilla-org-us-staging",
     "network-pulse": "network-pulse-staging",
     "network-pulse-api": "network-pulse-api-staging",
+    "donate-wagtail": "donate-wagtail-staging",
 }
 
 slack_webhook = os.environ["SLACK_PIPELINES_WEBHOOK"]


### PR DESCRIPTION
Since donate-wagtail was not pushed to prod since November 18th, it's probably a good idea to add it there :D