### PR TITLE
add thunderbird donate to the check and remove old donate stack

### DIFF
--- a/tasks/heroku_pipelines_check/slack_webhook.py
+++ b/tasks/heroku_pipelines_check/slack_webhook.py
@@ -76,8 +76,6 @@ if date.today().weekday() in range(0, 4):
             - Last line is an empty line.
             """
             title = output[1].strip("=\n").lstrip()
-            if re.search("donate", title):
-                title = "<@tchevalier>: " + title
             commits_list = output[3:-2]
             if commits_list:
                 if len(commits_list) >= 2:

--- a/tasks/heroku_pipelines_check/slack_webhook.py
+++ b/tasks/heroku_pipelines_check/slack_webhook.py
@@ -8,10 +8,10 @@ import os
 
 pipelines = {
     "foundation-site": "foundation-mofostaging-net",
-    "donate-mozilla-org": "donate-mozilla-org-us-staging",
     "network-pulse": "network-pulse-staging",
     "network-pulse-api": "network-pulse-api-staging",
-    "donate-wagtail": "donate-wagtail-staging",
+    "mofo-donate": "donate-wagtail-staging",
+    "thunderbird-donate": "thunderbird-donate-staging",
 }
 
 slack_webhook = os.environ["SLACK_PIPELINES_WEBHOOK"]


### PR DESCRIPTION
Update the pipelines' bot to add thunderbird donate to it: should help us keep track if we deployed both donates. I also removed the old donate stack since we're shutting it down.