### PR TITLE
Create Typeform cleanup task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .env
 .idea/
 venv/
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -85,5 +85,5 @@ to Typeform API documentation for endpoints we're using and how to Authenticate.
 2. execute `TYPEFORM_AUTH_TOKEN=some-value python tasks/typeform/delete_responses.py`
 
 #### Testing
-1. activate teh Python virtual environment (varies depending on OS)
+1. activate the Python virtual environment (varies depending on OS)
 2. execute `python tasks/typeform/test_delete_responses.py`

--- a/README.md
+++ b/README.md
@@ -73,3 +73,17 @@ Dependencies (`Pipefile`):
 - requests
 
 Usage: `python tasks/heroku_pipelines_check/slack_webhook.py`
+
+### tasks/typeform
+
+This task will clear out **all** of the responses collected for **every** form in an authenticated Typeform account.
+See the [docstrings in the code](/tasks/typeform/delete_responses.py) for more information on the process and for links
+to Typeform API documentation for endpoints we're using and how to Authenticate.
+
+#### Usage
+1. activate the Python virtual environment (varies depending on OS)
+2. execute `TYPEFORM_AUTH_TOKEN=some-value python tasks/typeform/delete_responses.py`
+
+#### Testing
+1. activate teh Python virtual environment (varies depending on OS)
+2. execute `python tasks/typeform/test_delete_responses.py`

--- a/tasks/typeform/delete_responses.py
+++ b/tasks/typeform/delete_responses.py
@@ -1,0 +1,141 @@
+import os
+import sys
+import requests
+
+
+# Print a message and then terminate the script with an exit code of 1
+def script_error(message):
+    print(message)
+    sys.exit(1)
+
+
+TYPEFORM_API = 'https://api.typeform.com/forms'
+
+try:
+    auth_tok = os.environ['TYPEFORM_AUTH_TOKEN']
+except KeyError:
+    script_error('TYPEFORM_AUTH_TOKEN not defined')
+
+
+# Authentication header class for requests
+class TokenAuth(requests.auth.AuthBase):
+    def __call__(self, token):
+        return token
+
+
+# Attempt to decode the JSON payload and exit with error if it fails
+def decode_json(response):
+    try:
+        return response.json()
+    except ValueError as err:
+        script_error(f'Failed to decode json payload for {response.request.method} {response.url}: {err}')
+
+
+# Make an HTTP request to the forms endpoint for a given page
+# Returns a tuple of (forms, page_count)
+def get_forms_by_page(page):
+    # https://developer.typeform.com/create/reference/retrieve-forms/#retrieve-forms
+    forms_response = requests.get(
+        f'{TYPEFORM_API}',
+        auth=TokenAuth(auth_tok),
+        params={
+            'page': page,
+            'page_size': 200
+        }
+    )
+
+    if forms_response.status_code != requests.codes.ok:
+        script_error(f'Failed to get list of forms: {forms_response.reason} - {forms_response.status_code}')
+
+    json_response = decode_json(forms_response)
+
+    return json_response['items'], json_response['page_count']
+
+
+# Make an HTTP request for a forms' responses, by page
+# Returns a tuple of (responses, page_count)
+def get_responses_for_form_by_page(form_id, page):
+    # https://developer.typeform.com/responses/reference/retrieve-responses/#retrieve-responses
+    responses_response = requests.get(
+        f'{TYPEFORM_API}/forms/{form_id}/responses',
+        auth=TokenAuth(auth_tok),
+        params={
+            'page_size': 1000,  # max allowed by API
+            'fields': 'response_id',  # only get IDs, not content
+        }
+    )
+
+    if responses_response.status_code != requests.codes.ok:
+        script_error(f'Failed to retrieve responses for form: {form_id} - {responses_response.status_code}')
+
+    json_response = decode_json(responses_response)
+
+    return json_response['items'], json_response['page_count']
+
+
+# Fetch all forms in the account, one page at a time
+# Returns a list of form ids
+def get_form_id_list():
+    form_list = []
+
+    # Get the first page of results, up to 200
+    response_forms, page_count = get_responses_by_page(1)
+    form_list.append(response_forms)
+
+    # We probably won't ever go above 200 forms, but if we do, fetch them too
+    if page_count > 1:
+        for next_page in range(2, page_count + 1):
+            response_forms, _ = get_forms_by_page(next_page)
+            form_list.append(response_forms)
+
+    # map the form_list into just form IDs
+    return map(lambda form_item: form_item.id, form_list)
+
+
+# Get all responses for a form, one page at a time
+# Returns a list of response ids
+def get_responses_for_form(form_id):
+    response_ids = []
+
+    responses, page_count = get_responses_for_form_by_page(form_id, 1)
+    response_ids.append(responses)
+
+    if page_count > 1:
+        for current_page in range(2, page_count + 1):
+            responses, _ = get_responses_for_form_by_page(form_id, current_page)
+            response_ids.append(responses)
+
+    return response_ids
+
+# Make an HTTP request to delete the specified responses
+def delete_responses(form_id, response_ids):
+    # https://developer.typeform.com/responses/reference/delete-responses/#delete-responses
+    del_response = requests.delete(
+        f'{TYPEFORM_API}/forms/{form_id}/responses',
+        auth=TokenAuth(auth_tok),
+        params={
+            'included_tokens': response_ids
+        }
+    )
+
+    if del_response.status_code != requests.codes.ok:
+        script_error(f'Failed to delete responses for form: {form_id} - {del_response.status_code}')
+
+
+# Delete all responses for a form, 25 at a time
+def delete_all_form_responses(form_id, response_ids):
+
+    while len(response_ids) > 0:
+        to_del = response_ids[:25]
+        response_ids = response_ids[25:]
+        delete_responses(form_id, to_del)
+
+
+# Get the list of form IDs
+form_id_list = get_form_id_list()
+
+# For each form, fetch the list of response IDs and delete them
+for form_id in form_id_list:
+    delete_all_form_responses(form_id, get_responses_for_form(form_id))
+
+

--- a/tasks/typeform/delete_responses.py
+++ b/tasks/typeform/delete_responses.py
@@ -4,12 +4,18 @@ import requests
 
 
 class ScriptError(Exception):
-    """Something went wrong in the script, details in self.message"""
+    """
+    Something went wrong in the script, details in self.message
+    """
     pass
 
 
 # Authentication header class for requests
 class TokenAuth(requests.auth.AuthBase):
+    """
+    Authentication class for requests.
+    Adds a bearer token to the Authorization header
+    """
     def __init__(self, token):
         self.token = token
 
@@ -19,25 +25,58 @@ class TokenAuth(requests.auth.AuthBase):
 
 
 class DeleteResponses:
-    def __init__(self):
-        self.TYPEFORM_API = 'https://api.typeform.com/forms'
+    """
+    A class encapsulating the logic for deleting all the responses in every form contained within the authenticated
+    Typeform account.
+    """
 
-        try:
-            self.token_auth = TokenAuth(os.environ['TYPEFORM_AUTH_TOKEN'])
-        except KeyError:
-            raise ScriptError('TYPEFORM_AUTH_TOKEN not defined')
+    TYPEFORM_API = 'https://api.typeform.com/forms'
 
-    # Attempt to decode the JSON payload and exit with error if it fails
+    def __init__(self, auth_token):
+        """
+        Initialize a class instance, setting the authentication token for making requests to TypeForm
+
+        :param auth_token: str
+            The token for making requests to TypeForm. Must have at least the following scopes:
+            Forms: Read
+            Responses: Read, Write
+
+        :raises ScriptError
+            If no auth_token provided to constructor
+        """
+        if not auth_token:
+            raise ScriptError('auth_token not provided')
+
+        self.token_auth = auth_token
+
     def decode_json(self, response):
+        """
+        Attempt to decode the JSON payload and exit with error if it fails
+
+        :param response: requests.Response
+            The response object from a requests request to convert into a dict
+        :return: dict
+            The dict representation of the JSON response
+        :raises ScriptError:
+            If payload is not valid JSON
+        """
         try:
             return response.json()
         except ValueError as err:
             raise ScriptError(f'Failed to decode json payload for {response.request.method} {response.url}: {err}')
 
-    # Make an HTTP request to the forms endpoint for a given page
-    # Returns a tuple of (forms, page_count)
     def get_forms_by_page(self, page):
-        # https://developer.typeform.com/create/reference/retrieve-forms/#retrieve-forms
+        """
+        Make an HTTP GET request to list a given page of forms in the authenticated Typeform account
+        API docs: https://developer.typeform.com/create/reference/retrieve-forms/#retrieve-forms
+
+        :param page: int
+            The page to fetch from the endpoint (will handle up to 200 forms per page)
+        :return: (list, int)
+            A tuple of the list of forms returned and the number of pages available to query.
+        :raises ScriptError:
+            If a non-OK status code is received from Typeform
+        """
         forms_response = requests.get(
             f'{self.TYPEFORM_API}',
             auth=self.token_auth,
@@ -54,15 +93,25 @@ class DeleteResponses:
 
         return json_response['items'], json_response['page_count']
 
-    # Make an HTTP request for a forms' responses, by page
-    # Returns a tuple of (responses, page_count)
     def get_form_responses_by_page(self, form_id, page):
-        # https://developer.typeform.com/responses/reference/retrieve-responses/#retrieve-responses
+        """
+        Make an HTTP GET request for a single page of a forms' responses. Up to 1000 per page.
+        API docs: https://developer.typeform.com/responses/reference/retrieve-responses/#retrieve-responses
+
+        :param form_id: str
+            The Typeform form's identifier
+        :param page: int
+            The page number to request
+        :return: (list, int)
+            A tuple containing the list of response IDs and the number of pages available to query.
+        :raises ScriptError:
+            If a non-OK status code is received from Typeform
+        """
         responses_response = requests.get(
             f'{self.TYPEFORM_API}/{form_id}/responses',
             auth=self.token_auth,
             params={
-                'page_size': 1000,  # max allowed by API
+                'page_size': 1000,
             }
         )
 
@@ -71,31 +120,40 @@ class DeleteResponses:
 
         json_response = self.decode_json(responses_response)
 
+        # map the responses so we only have their IDs & Convert the map generator object into a proper list
         response_ids = list(map(lambda response: response['response_id'], json_response['items']))
 
         return response_ids, json_response['page_count']
 
-    # Fetch all forms in the account, one page at a time
-    # Returns a list of form ids
     def get_form_id_list(self):
+        """
+        Fetch all forms in the account, one page at a time, concatenating all the pages together into a single list.
+
+        :return: list
+            A list of form ID strings
+        """
         form_list = []
 
-        # Get the first page of results, up to 200
         response_forms, page_count = self.get_forms_by_page(1)
         form_list.extend(response_forms)
 
-        # We probably won't ever go above 200 forms, but if we do, fetch them too
         if page_count > 1:
             for next_page in range(2, page_count + 1):
                 response_forms, _ = self.get_forms_by_page(next_page)
                 form_list.extend(response_forms)
 
-        # map the form_list into just form IDs
+        # map the list of forms into just form IDs and convert the map into a list.
         return list(map(lambda form_item: form_item['id'], form_list))
 
-    # Get all responses for a form, one page at a time
-    # Returns a list of response ids
     def get_form_responses(self, form_id):
+        """
+        Get all responses for a form, one page at a time and concatenating the lists of response IDs together
+
+        :param form_id: str
+            The string identifier for a form, whose responses will be requested
+        :return: list
+            A list of string identifiers representing every response in a form
+        """
         response_ids = []
 
         responses, page_count = self.get_form_responses_by_page(form_id, 1)
@@ -108,9 +166,21 @@ class DeleteResponses:
 
         return response_ids
 
-    # Make an HTTP request to delete the specified responses
     def delete_responses(self, form_id, response_ids):
-        # https://developer.typeform.com/responses/reference/delete-responses/#delete-responses
+        """
+        Make an HTTP DELETE request to delete all the responses identified in response_ids
+
+        API docs: https://developer.typeform.com/responses/reference/delete-responses/#delete-responses
+
+        :param form_id: str
+            The string identifier of a Typeform form
+        :param response_ids: list
+            A list of response ID strings that will be deleted
+        :return: None
+        :raises ScriptError:
+            If a non-OK status code is received from Typeform
+        """
+        #
         del_response = requests.delete(
             f'{self.TYPEFORM_API}/{form_id}/responses',
             auth=self.token_auth,
@@ -122,16 +192,35 @@ class DeleteResponses:
         if del_response.status_code != requests.codes.ok:
             raise ScriptError(f'Failed to delete responses for form: {form_id} - {del_response.status_code}')
 
-    # Delete all responses for a form, 25 at a time
+    #
     def delete_form_responses(self, form_id, response_ids):
+        """
+        Delete all responses for a form in batches of 25 ids (The request to delete responses has IDs in the query, so limiting it to something reasonably small)
+
+        :param form_id:
+            The string identifier of a Typeform form
+        :param response_ids:
+            A list of all response ID strings for the given Typeform form
+        :return: None
+        """
         num_to_delete = len(response_ids)
         while len(response_ids) > 0:
             to_del = response_ids[:25]
             response_ids = response_ids[25:]
             self.delete_responses(form_id, to_del)
+
         print(f'Deleted {num_to_delete} responses from form {form_id}')
 
     def execute(self):
+        """
+        Kicks off the chain of calls that glues every step together.
+
+        1. Fetch all forms (by page if necessary)
+        2. For each form, fetch all responses (by page if necessary)
+        3. For each form, delete all responses (in batches of 25)
+
+        :return: None
+        """
         try:
             # Get the list of form IDs
             form_id_list = self.get_form_id_list()
@@ -149,5 +238,10 @@ class DeleteResponses:
 
 
 if __name__ == '__main__':
-    delete_responses = DeleteResponses()
+    # If the script is called directly, instantiates and executes the process
+    if 'TYPEFORM_AUTH_TOKEN' not in os.environ:
+        print('You must set TYPEFORM_AUTH_TOKEN')
+        exit(1)
+
+    delete_responses = DeleteResponses(os.environ['TYPEFORM_AUTH_TOKEN'])
     delete_responses.execute()

--- a/tasks/typeform/delete_responses.py
+++ b/tasks/typeform/delete_responses.py
@@ -3,139 +3,151 @@ import sys
 import requests
 
 
-# Print a message and then terminate the script with an exit code of 1
-def script_error(message):
-    print(message)
-    sys.exit(1)
-
-
-TYPEFORM_API = 'https://api.typeform.com/forms'
-
-try:
-    auth_tok = os.environ['TYPEFORM_AUTH_TOKEN']
-except KeyError:
-    script_error('TYPEFORM_AUTH_TOKEN not defined')
+class ScriptError(Exception):
+    """Something went wrong in the script, details in self.message"""
+    pass
 
 
 # Authentication header class for requests
 class TokenAuth(requests.auth.AuthBase):
-    def __call__(self, token):
-        return token
+    def __init__(self, token):
+        self.token = token
+
+    def __call__(self, request):
+        request.headers['Authorization'] = f'Bearer {self.token}'
+        return request
 
 
-# Attempt to decode the JSON payload and exit with error if it fails
-def decode_json(response):
-    try:
-        return response.json()
-    except ValueError as err:
-        script_error(f'Failed to decode json payload for {response.request.method} {response.url}: {err}')
+class DeleteResponses:
+    def __init__(self):
+        self.TYPEFORM_API = 'https://api.typeform.com/forms'
+
+        try:
+            self.token_auth = TokenAuth(os.environ['TYPEFORM_AUTH_TOKEN'])
+        except KeyError:
+            raise ScriptError('TYPEFORM_AUTH_TOKEN not defined')
+
+    # Attempt to decode the JSON payload and exit with error if it fails
+    def decode_json(self, response):
+        try:
+            return response.json()
+        except ValueError as err:
+            raise ScriptError(f'Failed to decode json payload for {response.request.method} {response.url}: {err}')
+
+    # Make an HTTP request to the forms endpoint for a given page
+    # Returns a tuple of (forms, page_count)
+    def get_forms_by_page(self, page):
+        # https://developer.typeform.com/create/reference/retrieve-forms/#retrieve-forms
+        forms_response = requests.get(
+            f'{self.TYPEFORM_API}',
+            auth=self.token_auth,
+            params={
+                'page': page,
+                'page_size': 200
+            }
+        )
+
+        if forms_response.status_code != requests.codes.ok:
+            raise ScriptError(f'Failed to get list of forms: {forms_response.reason} - {forms_response.status_code}')
+
+        json_response = self.decode_json(forms_response)
+
+        return json_response['items'], json_response['page_count']
+
+    # Make an HTTP request for a forms' responses, by page
+    # Returns a tuple of (responses, page_count)
+    def get_form_responses_by_page(self, form_id, page):
+        # https://developer.typeform.com/responses/reference/retrieve-responses/#retrieve-responses
+        responses_response = requests.get(
+            f'{self.TYPEFORM_API}/{form_id}/responses',
+            auth=self.token_auth,
+            params={
+                'page_size': 1000,  # max allowed by API
+            }
+        )
+
+        if responses_response.status_code != requests.codes.ok:
+            raise ScriptError(f'Failed to retrieve responses for form: {form_id} - {responses_response.status_code}')
+
+        json_response = self.decode_json(responses_response)
+
+        response_ids = list(map(lambda response: response['response_id'], json_response['items']))
+
+        return response_ids, json_response['page_count']
+
+    # Fetch all forms in the account, one page at a time
+    # Returns a list of form ids
+    def get_form_id_list(self):
+        form_list = []
+
+        # Get the first page of results, up to 200
+        response_forms, page_count = self.get_forms_by_page(1)
+        form_list.extend(response_forms)
+
+        # We probably won't ever go above 200 forms, but if we do, fetch them too
+        if page_count > 1:
+            for next_page in range(2, page_count + 1):
+                response_forms, _ = self.get_forms_by_page(next_page)
+                form_list.extend(response_forms)
+
+        # map the form_list into just form IDs
+        return list(map(lambda form_item: form_item['id'], form_list))
+
+    # Get all responses for a form, one page at a time
+    # Returns a list of response ids
+    def get_form_responses(self, form_id):
+        response_ids = []
+
+        responses, page_count = self.get_form_responses_by_page(form_id, 1)
+        response_ids.extend(responses)
+
+        if page_count > 1:
+            for current_page in range(2, page_count + 1):
+                responses, _ = self.get_form_responses_by_page(form_id, current_page)
+                response_ids.extend(responses)
+
+        return response_ids
+
+    # Make an HTTP request to delete the specified responses
+    def delete_responses(self, form_id, response_ids):
+        # https://developer.typeform.com/responses/reference/delete-responses/#delete-responses
+        del_response = requests.delete(
+            f'{self.TYPEFORM_API}/{form_id}/responses',
+            auth=self.token_auth,
+            params={
+                'included_tokens': response_ids
+            }
+        )
+
+        if del_response.status_code != requests.codes.ok:
+            raise ScriptError(f'Failed to delete responses for form: {form_id} - {del_response.status_code}')
+
+    # Delete all responses for a form, 25 at a time
+    def delete_form_responses(self, form_id, response_ids):
+        num_to_delete = len(response_ids)
+        while len(response_ids) > 0:
+            to_del = response_ids[:25]
+            response_ids = response_ids[25:]
+            self.delete_responses(form_id, to_del)
+        print(f'Deleted {num_to_delete} responses from form {form_id}')
+
+    def execute(self):
+        try:
+            # Get the list of form IDs
+            form_id_list = self.get_form_id_list()
+
+            if len(form_id_list) == 0:
+                print('No forms in account')
+                exit(0)
+
+            # For each form, fetch the list of response IDs and delete them
+            for form_id in form_id_list:
+                form_responses = self.get_form_responses(form_id)
+                self.delete_form_responses(form_id, form_responses)
+        except ScriptError as err:
+            print(f'Failed to execute: {err.message}')
 
 
-# Make an HTTP request to the forms endpoint for a given page
-# Returns a tuple of (forms, page_count)
-def get_forms_by_page(page):
-    # https://developer.typeform.com/create/reference/retrieve-forms/#retrieve-forms
-    forms_response = requests.get(
-        f'{TYPEFORM_API}',
-        auth=TokenAuth(auth_tok),
-        params={
-            'page': page,
-            'page_size': 200
-        }
-    )
-
-    if forms_response.status_code != requests.codes.ok:
-        script_error(f'Failed to get list of forms: {forms_response.reason} - {forms_response.status_code}')
-
-    json_response = decode_json(forms_response)
-
-    return json_response['items'], json_response['page_count']
-
-
-# Make an HTTP request for a forms' responses, by page
-# Returns a tuple of (responses, page_count)
-def get_responses_for_form_by_page(form_id, page):
-    # https://developer.typeform.com/responses/reference/retrieve-responses/#retrieve-responses
-    responses_response = requests.get(
-        f'{TYPEFORM_API}/forms/{form_id}/responses',
-        auth=TokenAuth(auth_tok),
-        params={
-            'page_size': 1000,  # max allowed by API
-            'fields': 'response_id',  # only get IDs, not content
-        }
-    )
-
-    if responses_response.status_code != requests.codes.ok:
-        script_error(f'Failed to retrieve responses for form: {form_id} - {responses_response.status_code}')
-
-    json_response = decode_json(responses_response)
-
-    return json_response['items'], json_response['page_count']
-
-
-# Fetch all forms in the account, one page at a time
-# Returns a list of form ids
-def get_form_id_list():
-    form_list = []
-
-    # Get the first page of results, up to 200
-    response_forms, page_count = get_responses_by_page(1)
-    form_list.append(response_forms)
-
-    # We probably won't ever go above 200 forms, but if we do, fetch them too
-    if page_count > 1:
-        for next_page in range(2, page_count + 1):
-            response_forms, _ = get_forms_by_page(next_page)
-            form_list.append(response_forms)
-
-    # map the form_list into just form IDs
-    return map(lambda form_item: form_item.id, form_list)
-
-
-# Get all responses for a form, one page at a time
-# Returns a list of response ids
-def get_responses_for_form(form_id):
-    response_ids = []
-
-    responses, page_count = get_responses_for_form_by_page(form_id, 1)
-    response_ids.append(responses)
-
-    if page_count > 1:
-        for current_page in range(2, page_count + 1):
-            responses, _ = get_responses_for_form_by_page(form_id, current_page)
-            response_ids.append(responses)
-
-    return response_ids
-
-# Make an HTTP request to delete the specified responses
-def delete_responses(form_id, response_ids):
-    # https://developer.typeform.com/responses/reference/delete-responses/#delete-responses
-    del_response = requests.delete(
-        f'{TYPEFORM_API}/forms/{form_id}/responses',
-        auth=TokenAuth(auth_tok),
-        params={
-            'included_tokens': response_ids
-        }
-    )
-
-    if del_response.status_code != requests.codes.ok:
-        script_error(f'Failed to delete responses for form: {form_id} - {del_response.status_code}')
-
-
-# Delete all responses for a form, 25 at a time
-def delete_all_form_responses(form_id, response_ids):
-
-    while len(response_ids) > 0:
-        to_del = response_ids[:25]
-        response_ids = response_ids[25:]
-        delete_responses(form_id, to_del)
-
-
-# Get the list of form IDs
-form_id_list = get_form_id_list()
-
-# For each form, fetch the list of response IDs and delete them
-for form_id in form_id_list:
-    delete_all_form_responses(form_id, get_responses_for_form(form_id))
-
-
+if __name__ == '__main__':
+    delete_responses = DeleteResponses()
+    delete_responses.execute()

--- a/tasks/typeform/test_delete_responses.py
+++ b/tasks/typeform/test_delete_responses.py
@@ -8,6 +8,7 @@ from delete_responses import (
     ScriptError
 )
 
+auth_token = 'test-auth-token'
 mock_forms_page_1 = [{'id': '1'}, {'id': '2'}]
 mock_forms_page_2 = [{'id': '3'}, {'id': '4'}]
 mock_forms_page_3 = [{'id': '5'}, {'id': '6'}]
@@ -47,7 +48,7 @@ class TestDeleteResponses(TestCase):
     @patch('delete_responses.DeleteResponses.get_forms_by_page')
     def test_get_form_id_list_empty(self, mock_get_forms_by_page):
         mock_get_forms_by_page.return_value = ([], 1)
-        delete_responses = DeleteResponses()
+        delete_responses = DeleteResponses(auth_token)
         form_list = delete_responses.get_form_id_list()
         mock_get_forms_by_page.assert_called_once()
         self.assertEqual(form_list, [])
@@ -55,7 +56,7 @@ class TestDeleteResponses(TestCase):
     @patch('delete_responses.DeleteResponses.get_forms_by_page')
     def test_get_form_id_list_one_page(self, mock_get_forms_by_page):
         mock_get_forms_by_page.return_value = (mock_forms_page_1, 1)
-        delete_responses = DeleteResponses()
+        delete_responses = DeleteResponses(auth_token)
         form_list = delete_responses.get_form_id_list()
         mock_get_forms_by_page.assert_called_once()
         self.assertEqual(form_list, ['1', '2'])
@@ -63,7 +64,7 @@ class TestDeleteResponses(TestCase):
     @patch('delete_responses.DeleteResponses.get_forms_by_page')
     def test_get_form_id_list_multi_page(self, mock_get_forms_by_page):
         mock_get_forms_by_page.side_effect = mock_multi_page_return_values
-        delete_responses = DeleteResponses()
+        delete_responses = DeleteResponses(auth_token)
         form_list = delete_responses.get_form_id_list()
         calls = [call(1), call(2), call(3)]
         mock_get_forms_by_page.assert_has_calls(calls)
@@ -74,7 +75,7 @@ class TestDeleteResponses(TestCase):
         mock_response = Mock()
         mock_response.status_code = 403
         mock_get.side_effect = mock_response
-        delete_responses = DeleteResponses()
+        delete_responses = DeleteResponses(auth_token)
         self.assertRaises(ScriptError, delete_responses.get_forms_by_page, 1)
 
     @patch('requests.get')
@@ -83,7 +84,7 @@ class TestDeleteResponses(TestCase):
         mock_response.status_code = 200
         mock_response.json.side_effect = ValueError('This is not JSON')
         mock_get.side_effect = mock_response
-        delete_responses = DeleteResponses()
+        delete_responses = DeleteResponses(auth_token)
         self.assertRaises(ScriptError, delete_responses.get_forms_by_page, 1)
 
     @patch('requests.get')
@@ -95,7 +96,7 @@ class TestDeleteResponses(TestCase):
             'page_count': 1
         }
         mock_get.return_value = mock_response
-        delete_responses = DeleteResponses()
+        delete_responses = DeleteResponses(auth_token)
         response_list = delete_responses.get_form_responses('1')
         mock_get.assert_called_once()
         self.assertEqual(response_list, ['1', '2', '3'])
@@ -106,7 +107,7 @@ class TestDeleteResponses(TestCase):
         mock_response.status_code = 200
         mock_response.json.side_effect = mock_form_responses_return_values
         mock_get.return_value = mock_response
-        delete_responses = DeleteResponses()
+        delete_responses = DeleteResponses(auth_token)
         response_list = delete_responses.get_form_responses('1')
         self.assertEqual(mock_get.call_count, 3)
         self.assertEqual(response_list, ['1', '2', '3', '4', '5', '6', '7', '8', '9'])
@@ -116,7 +117,7 @@ class TestDeleteResponses(TestCase):
         mock_response = Mock()
         mock_response.status_code = 403
         mock_get.side_effect = mock_response
-        delete_responses = DeleteResponses()
+        delete_responses = DeleteResponses(auth_token)
         self.assertRaises(ScriptError, delete_responses.get_form_responses, 1)
 
     @patch('requests.get')
@@ -125,7 +126,7 @@ class TestDeleteResponses(TestCase):
         mock_response.status_code = 200
         mock_response.json.side_effect = ValueError('This is not JSON')
         mock_get.side_effect = mock_response
-        delete_responses = DeleteResponses()
+        delete_responses = DeleteResponses(auth_token)
         self.assertRaises(ScriptError, delete_responses.get_form_responses, 1)
 
     # TODO: test delete_all_form_responses and deleteresponses
@@ -135,7 +136,7 @@ class TestDeleteResponses(TestCase):
         mock_response = Mock()
         mock_response.status_code = 200
         mock_delete.return_value = mock_response
-        delete_responses = DeleteResponses()
+        delete_responses = DeleteResponses(auth_token)
         try:
             delete_responses.delete_form_responses('1', ['1', '2', '3'])
         except ScriptError:
@@ -143,7 +144,7 @@ class TestDeleteResponses(TestCase):
 
     @patch('delete_responses.DeleteResponses.delete_responses')
     def test_delete_form_responses_batched(self, mock_delete_responses):
-        delete_responses = DeleteResponses()
+        delete_responses = DeleteResponses(auth_token)
         response_ids = list(map(str, range(1, 300)))
         try:
             delete_responses.delete_form_responses('1', response_ids)
@@ -156,7 +157,7 @@ class TestDeleteResponses(TestCase):
         mock_response = Mock()
         mock_response.status_code = 403
         mock_get.side_effect = mock_response
-        delete_responses = DeleteResponses()
+        delete_responses = DeleteResponses(auth_token)
         self.assertRaises(ScriptError, delete_responses.delete_responses, '1', ['1', '2', '3'])
 
 

--- a/tasks/typeform/test_delete_responses.py
+++ b/tasks/typeform/test_delete_responses.py
@@ -1,0 +1,164 @@
+import unittest
+from unittest import TestCase
+from unittest.mock import Mock, patch, call
+
+from delete_responses import (
+    DeleteResponses,
+    TokenAuth,
+    ScriptError
+)
+
+mock_forms_page_1 = [{'id': '1'}, {'id': '2'}]
+mock_forms_page_2 = [{'id': '3'}, {'id': '4'}]
+mock_forms_page_3 = [{'id': '5'}, {'id': '6'}]
+mock_multi_page_return_values = [
+    (mock_forms_page_1, 3),
+    (mock_forms_page_2, 3),
+    (mock_forms_page_3, 3)
+]
+mock_form_responses_page_1 = [{'response_id': '1'}, {'response_id': '2'}, {'response_id': '3'}]
+mock_form_responses_page_2 = [{'response_id': '4'}, {'response_id': '5'}, {'response_id': '6'}]
+mock_form_responses_page_3 = [{'response_id': '7'}, {'response_id': '8'}, {'response_id': '9'}]
+mock_form_responses_return_values = [
+    {
+        'items': mock_form_responses_page_1,
+        'page_count': 3
+    },
+    {
+        'items': mock_form_responses_page_2,
+        'page_count': 3
+    },
+    {
+        'items': mock_form_responses_page_3,
+        'page_count': 3
+    }
+]
+
+
+class TestDeleteResponses(TestCase):
+    def test_token_auth(self):
+        test_value = 'test_token'
+        token_auth = TokenAuth(test_value)
+        request = Mock()
+        request.headers = {}
+        token_auth(request)
+        self.assertEqual(request.headers.get('Authorization', None), f'Bearer {test_value}')
+
+    @patch('delete_responses.DeleteResponses.get_forms_by_page')
+    def test_get_form_id_list_empty(self, mock_get_forms_by_page):
+        mock_get_forms_by_page.return_value = ([], 1)
+        delete_responses = DeleteResponses()
+        form_list = delete_responses.get_form_id_list()
+        mock_get_forms_by_page.assert_called_once()
+        self.assertEqual(form_list, [])
+
+    @patch('delete_responses.DeleteResponses.get_forms_by_page')
+    def test_get_form_id_list_one_page(self, mock_get_forms_by_page):
+        mock_get_forms_by_page.return_value = (mock_forms_page_1, 1)
+        delete_responses = DeleteResponses()
+        form_list = delete_responses.get_form_id_list()
+        mock_get_forms_by_page.assert_called_once()
+        self.assertEqual(form_list, ['1', '2'])
+
+    @patch('delete_responses.DeleteResponses.get_forms_by_page')
+    def test_get_form_id_list_multi_page(self, mock_get_forms_by_page):
+        mock_get_forms_by_page.side_effect = mock_multi_page_return_values
+        delete_responses = DeleteResponses()
+        form_list = delete_responses.get_form_id_list()
+        calls = [call(1), call(2), call(3)]
+        mock_get_forms_by_page.assert_has_calls(calls)
+        self.assertEqual(form_list, ['1', '2', '3', '4', '5', '6'])
+
+    @patch('requests.get')
+    def test_get_forms_by_page_raises_err(self, mock_get):
+        mock_response = Mock()
+        mock_response.status_code = 403
+        mock_get.side_effect = mock_response
+        delete_responses = DeleteResponses()
+        self.assertRaises(ScriptError, delete_responses.get_forms_by_page, 1)
+
+    @patch('requests.get')
+    def test_get_forms_by_page_bad_json(self, mock_get):
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.side_effect = ValueError('This is not JSON')
+        mock_get.side_effect = mock_response
+        delete_responses = DeleteResponses()
+        self.assertRaises(ScriptError, delete_responses.get_forms_by_page, 1)
+
+    @patch('requests.get')
+    def test_get_form_responses_one_page(self, mock_get):
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            'items': mock_form_responses_page_1,
+            'page_count': 1
+        }
+        mock_get.return_value = mock_response
+        delete_responses = DeleteResponses()
+        response_list = delete_responses.get_form_responses('1')
+        mock_get.assert_called_once()
+        self.assertEqual(response_list, ['1', '2', '3'])
+
+    @patch('requests.get')
+    def test_get_form_responses_form_multi_page(self, mock_get):
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.side_effect = mock_form_responses_return_values
+        mock_get.return_value = mock_response
+        delete_responses = DeleteResponses()
+        response_list = delete_responses.get_form_responses('1')
+        self.assertEqual(mock_get.call_count, 3)
+        self.assertEqual(response_list, ['1', '2', '3', '4', '5', '6', '7', '8', '9'])
+
+    @patch('requests.get')
+    def test_get_form_responses_by_page_raises_err(self, mock_get):
+        mock_response = Mock()
+        mock_response.status_code = 403
+        mock_get.side_effect = mock_response
+        delete_responses = DeleteResponses()
+        self.assertRaises(ScriptError, delete_responses.get_form_responses, 1)
+
+    @patch('requests.get')
+    def test_get_form_responses_by_page_bad_json(self, mock_get):
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.side_effect = ValueError('This is not JSON')
+        mock_get.side_effect = mock_response
+        delete_responses = DeleteResponses()
+        self.assertRaises(ScriptError, delete_responses.get_form_responses, 1)
+
+    # TODO: test delete_all_form_responses and deleteresponses
+
+    @patch('requests.delete')
+    def test_delete_form_responses(self, mock_delete):
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_delete.return_value = mock_response
+        delete_responses = DeleteResponses()
+        try:
+            delete_responses.delete_form_responses('1', ['1', '2', '3'])
+        except ScriptError:
+            self.fail('delete_responses.delete_form_responses() raised an exception unexpectedly')
+
+    @patch('delete_responses.DeleteResponses.delete_responses')
+    def test_delete_form_responses_batched(self, mock_delete_responses):
+        delete_responses = DeleteResponses()
+        response_ids = list(map(str, range(1, 300)))
+        try:
+            delete_responses.delete_form_responses('1', response_ids)
+        except ScriptError:
+            self.fail('delete_responses.delete_form_responses() raised an exception unexpectedly')
+        self.assertEqual(mock_delete_responses.call_count, 12)
+
+    @patch('requests.delete')
+    def test_delete_responses_raises(self, mock_get):
+        mock_response = Mock()
+        mock_response.status_code = 403
+        mock_get.side_effect = mock_response
+        delete_responses = DeleteResponses()
+        self.assertRaises(ScriptError, delete_responses.delete_responses, '1', ['1', '2', '3'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #36 

Add a task to:

1. Fetch all forms (by page if necessary)
2. For each form, fetch all responses (by page if necessary)
3. For each form, delete all responses (in batches of 25)

Included detailed code documentation, unit tests, and a README update.