### PR TITLE
Stack update

### DIFF
--- a/Aptfile
+++ b/Aptfile
@@ -1,2 +1,1 @@
-:repo:deb http://archive.ubuntu.com/ubuntu xenial main universe
 jq

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.7.10
+python-3.9


### PR DESCRIPTION
This PR updates the tech stack to a supported version of Python (3.9) by the `heroku-22` stack and removes an outdated Ubuntu version from the build process.

`jq` dependency available at the updated default stack.