### PR TITLE
Update MoFo copy Prod DB to Staging script to update staging site bindings

### DIFF
--- a/tasks/clone_foundation_site/task.sh
+++ b/tasks/clone_foundation_site/task.sh
@@ -111,6 +111,9 @@ python -m awscli s3 sync --region ${S3_REGION} s3://${PRODUCTION_S3_BUCKET}/${PR
 echo "Running migrations..."
 heroku run -a ${staging_app} -- python network-api/manage.py migrate --no-input
 
+echo "Resetting wagtail site bindings to point to staging hostnames..."
+heroku run -a ${staging_app} -- python network-api/manage.py update_staging_site_hostnames
+
 echo "Scaling web dynos on staging to 1..."
 heroku ps:scale -a ${staging_app} web=1
 

--- a/tasks/clone_foundation_site/task.sh
+++ b/tasks/clone_foundation_site/task.sh
@@ -109,10 +109,10 @@ echo "Syncing S3 Buckets"
 python -m awscli s3 sync --region ${S3_REGION} s3://${PRODUCTION_S3_BUCKET}/${PRODUCTION_S3_PREFIX} s3://${STAGING_S3_BUCKET}/${STAGING_S3_PREFIX}
 
 echo "Running migrations..."
-heroku run -a ${staging_app} -- python network-api/manage.py migrate --no-input
+heroku run -a ${staging_app} -- python manage.py migrate --no-input
 
 echo "Resetting wagtail site bindings to point to staging hostnames..."
-heroku run -a ${staging_app} -- python network-api/manage.py update_staging_site_hostnames
+heroku run -a ${staging_app} -- python manage.py update_staging_site_hostnames
 
 echo "Scaling web dynos on staging to 1..."
 heroku ps:scale -a ${staging_app} web=1


### PR DESCRIPTION
# Description 
This PR updates our MoFo site cron job script to now call the new script implemented in https://github.com/MozillaFoundation/foundation.mozilla.org/pull/14691/, which updates the staging site bindings to point back to staging hostnames after copying the prod DB.